### PR TITLE
Se agrega método para borrar tokens hasta la fecha deseada

### DIFF
--- a/src/main/java/io/github/jokoframework/security/repositories/ITokenRepository.java
+++ b/src/main/java/io/github/jokoframework/security/repositories/ITokenRepository.java
@@ -41,5 +41,7 @@ public interface ITokenRepository extends JpaRepository<TokenEntity, String> {
     @Query("DELETE from TokenEntity t WHERE t.expiration <= :fromDate")
     int deleteExpiredTokens(@Param("fromDate") Date fromDate);
 
-
+    @Modifying
+    @Query("DELETE from TokenEntity t WHERE t.issuedAt <= :fromDate")
+    int deleteTokensFromDate(@Param("fromDate") Date fromDate);
 }

--- a/src/main/java/io/github/jokoframework/security/services/ITokenService.java
+++ b/src/main/java/io/github/jokoframework/security/services/ITokenService.java
@@ -1,5 +1,6 @@
 package io.github.jokoframework.security.services;
 
+import java.util.Date;
 import java.util.List;
 
 import io.github.jokoframework.security.JokoJWTClaims;
@@ -26,7 +27,7 @@ public interface ITokenService {
     /**
      * Devuelve false si el token no fue revocado, en cualquier otro caso
      * devuelve true
-     * 
+     *
      * @param jti
      * @return
      */
@@ -36,11 +37,13 @@ public interface ITokenService {
      * Realiza el parsing del token JWT. Este metodo tira un
      * {@link JwtException} si no se pudo comprobar la firma o el certificado
      * expiro
-     * 
+     *
      * @param token
      * @return
      */
     JokoJWTClaims parse(String token);
 
     int deleteExpiredTokens();
+
+    void revokeTokensUntil(Date date);
 }

--- a/src/main/java/io/github/jokoframework/security/services/impl/TokenServiceImpl.java
+++ b/src/main/java/io/github/jokoframework/security/services/impl/TokenServiceImpl.java
@@ -324,6 +324,11 @@ public class TokenServiceImpl implements ITokenService {
     }
 
     @Override
+    public void revokeTokensUntil(Date date) {
+    	tokenRepository.deleteTokensFromDate(date);
+    }
+
+    @Override
     public int deleteExpiredTokens() {
         Date now = new Date();
         return tokenRepository.deleteExpiredTokens(now);


### PR DESCRIPTION
Se desea contar con un worker para todos los días a las 00:00 hs revocar los tokens del día anterior, y el mismo usa la implementación por defecto del TokenService, se agrega la posibilidad de revocar tokens expedidos hasta la fecha que se recibe como parámetro.