### PR TITLE
Actualiza librería por parche de seguridad

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.jokoframework</groupId>
     <artifactId>joko-security</artifactId>
 
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -26,7 +26,7 @@
         <dependency-check.version>5.2.0</dependency-check.version>
         <postgresql.version>42.2.5</postgresql.version>
         <guava.version>27.1-jre</guava.version>
-        <jackson-databind.version>2.9.9.1</jackson-databind.version>
+        <jackson-databind.version>2.9.9.2</jackson-databind.version>
     </properties>
 
     <!--Dependencias -->


### PR DESCRIPTION
- Actualiza jackson-databind debido a: CVE-2019-14379 y
  CVE-2019-14439