### PR TITLE
Ajusta el tipo de dato para PKs de BIGINT a BIGSERIAL

### DIFF
--- a/src/main/resources/db/liquibase/db-changelog-inicial.xml
+++ b/src/main/resources/db/liquibase/db-changelog-inicial.xml
@@ -28,7 +28,7 @@
         <createTable tableName="consumer_api"
                      schemaName="joko_security"
                      remarks="guarda los consumer para integracion con terceros a nivel de API">
-            <column name="id" type="BIGINT">
+            <column name="id" type="BIGSERIAL">
                 <constraints nullable="false"/>
             </column>
             <column name="access_level" type="VARCHAR(255)"/>
@@ -61,7 +61,7 @@
 
     <changeSet author="danicricco" id="1518643732286-8">
         <createTable tableName="principal_session" schemaName="joko_security">
-            <column name="id" type="BIGINT">
+            <column name="id" type="BIGSERIAL">
                 <constraints nullable="false"/>
             </column>
             <column name="app_description" type="VARCHAR(255)"/>
@@ -83,7 +83,7 @@
         <createTable tableName="security_profile"
                      schemaName="joko_security"
                      remarks="Establece la configuracion de emision de tokens para los distintos ambientes">
-            <column name="id" type="BIGINT">
+            <column name="id" type="BIGSERIAL">
                 <constraints nullable="false"/>
             </column>
             <column name="access_token_timeout_seconds" type="INT"/>
@@ -152,7 +152,7 @@
         <createTable tableName="audit_session"
                      schemaName="joko_security"
                      remarks="Stores the last login of a given user">
-            <column name="id" type="BIGINT">
+            <column name="id" type="BIGSERIAL">
                 <constraints nullable="false"/>
             </column>
             <column name="creation_date" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>


### PR DESCRIPTION
- Corrige los tipos de datos para las claves primarias de las tablas generadas mediante liquibase, los mismoa 