### PR TITLE
Security fix 2022-12

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -248,5 +248,7 @@
 			]]>
 		</notes>
    		<cve>CVE-2016-1000027</cve>
+		<!-- temporary 2022-12-07 - afeltes - https://nvd.nist.gov/vuln/detail/CVE-2022-1471 -->
+        	<cve>CVE-2022-1471</cve>
 	</suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.jokoframework</groupId>
     <artifactId>joko-security</artifactId>
 
-    <version>1.2.12</version>
+    <version>1.2.13</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -16,15 +16,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <spring-boot.version>2.6.10</spring-boot.version>
+        <spring-boot.version>2.7.6</spring-boot.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-io.version>2.11.0</commons-io.version>
         <httpclient.version>4.5.13</httpclient.version>
         <jjwt.version>0.9.1</jjwt.version>
-        <spring-security-test.version>5.6.6</spring-security-test.version>
+        <spring-security-test.version>5.8.0</spring-security-test.version>
         <commons-collections4.version>4.4</commons-collections4.version>
-        <dependency-check.version>7.1.1</dependency-check.version>
-        <postgresql.version>42.4.0</postgresql.version>
+        <dependency-check.version>7.4.0</dependency-check.version>
+        <postgresql.version>42.5.1</postgresql.version>
         <guava.version>30.1.1-jre</guava.version>
         <jackson-databind.version>2.13.3</jackson-databind.version>
         <jsonassert.version>1.3.0</jsonassert.version>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgresql.version}</version><!--$NO-MVN-MAN-VER$ -->
+            <version>${postgresql.version}</version>
         </dependency>
 
         <!-- http://mvnrepository.com/artifact/com.h2database/h2 -->
@@ -245,6 +245,19 @@
 
 
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+
+            <!-- security fix pending https://nvd.nist.gov/vuln/detail/CVE-2022-1471 -->
+            <dependency>
+                <groupId>org.yaml</groupId>
+        	<artifactId>snakeyaml</artifactId>
+        	<version>1.33</version>
+      	    </dependency>
+
+   	</dependencies>
+    </dependencyManagement>    
 
     <!--Plugins -->
     <build>


### PR DESCRIPTION
Remove critical security issues inherited from dependencies. 
There are still no fix for

*  https://nvd.nist.gov/vuln/detail/CVE-2022-1471 
* [CVE-2022-41854](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41854)

https://mvnrepository.com/artifact/org.yaml/snakeyaml/1.33
